### PR TITLE
Add log_dir creation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Create a `config.json` file in the project root with the following keys:
 - `cert_pass`: Password for the certificate.
 - `cnpj`: The company's CNPJ used to log in to the portal.
 - `output_dir`: Directory where downloaded NFSe XML files will be saved.
+- `log_dir`: Directory where log files will be written.
 - `delay_seconds`: Number of seconds to wait between requests.
 - `auto_start`: `true` to start downloading automatically when the script launches.
 - `timeout` *(optional)*: Request timeout in seconds. Defaults to `30`.
@@ -39,6 +40,7 @@ Example `config.json`:
   "cert_pass": "my_password",
   "cnpj": "12345678000199",
   "output_dir": "./xml",
+  "log_dir": "./logs",
   "delay_seconds": 2,
   "auto_start": true,
   "timeout": 30

--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -110,6 +110,7 @@ class App:
             DELAY_SECONDS = int(cfg.get("delay_seconds", 60))
 
             os.makedirs(OUTPUT_DIR, exist_ok=True)
+            os.makedirs(LOG_DIR, exist_ok=True)
             BASE_URL = "https://adn.nfse.gov.br/contribuintes/DFe"
             log_name = os.path.join(LOG_DIR, f"log_nfse_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.txt")
             self.log_file = open(log_name, "w", encoding="utf-8")


### PR DESCRIPTION
## Summary
- ensure log directory is created before writing log files
- document `log_dir` in README

## Testing
- `python3 -m py_compile download_nfse_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_685df2dfa2748329a56ab6a383611606