### PR TITLE
Add configurable timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create a `config.json` file in the project root with the following keys:
 - `log_dir`: Directory where log files will be written.
 - `delay_seconds`: Number of seconds to wait between requests.
 - `auto_start`: `true` to start downloading automatically when the script launches.
-- `timeout` *(optional)*: Request timeout in seconds. Defaults to `30`.
+- `timeout` *(opcional)*: tempo limite das requisições em segundos (padrão `30`).
 
 Example `config.json`:
 

--- a/config.json
+++ b/config.json
@@ -5,5 +5,6 @@
   "output_dir": "./xml",
   "log_dir": "logs",
   "delay_seconds": 10,
-  "auto_start": false
+  "auto_start": false,
+  "timeout": 30
 }

--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -130,7 +130,7 @@ class App:
                     url = f"{BASE_URL}/{nsu:020d}?cnpj={CNPJ}"
                     self.write(f"Consultando NSU {nsu} para CNPJ {CNPJ}...", log=True)
                     try:
-                        resp = sess.get(url)
+                        resp = sess.get(url, timeout=self.config.get("timeout", 30))
                     except Exception as e:
                         self.write(f"Erro de conexão: {e}", log=True)
                         salvar_ultimo_nsu(CNPJ, nsu)


### PR DESCRIPTION
## Summary
- support `timeout` value in `config.json`
- pass timeout to `sess.get`
- document request timeout option in Portuguese

## Testing
- `python3 -m py_compile download_nfse_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_685df43fa3588329acf4f5c75bf69d09