### PR TITLE
Handle auto-start exit

### DIFF
--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -259,6 +259,8 @@ class App:
             self.running = False
             self.start_button.config(state=tk.NORMAL)
             self.stop_button.config(state=tk.DISABLED)
+            if self.config.get("auto_start"):
+                self.root.after(1000, self.root.destroy)
 
 def ler_config():
     if not os.path.exists(CONFIG_FILE):


### PR DESCRIPTION
## Summary
- let the app close automatically after processing when `auto_start` is enabled

## Testing
- `python -m py_compile download_nfse_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_685dfaeee078832986d06f1ae1190d7e