### PR TITLE
Add build script and update packaging steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,8 @@ Para criar um executável standalone:
 pip install pyinstaller
 pyinstaller --onefile download_nfse_gui.py
 ```
-
 O executável será gerado dentro da pasta `dist`.
+Copie o `config.json` e o arquivo de certificado (`.pfx` ou `.pem`) para esse
+diretório para que o programa consiga localizá-los em tempo de execução.
+
+Um script auxiliar `build_exe.sh` está disponível para automatizar essas etapas.

--- a/build_exe.sh
+++ b/build_exe.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Build the standalone executable for download_nfse_gui.py using PyInstaller.
+# Install PyInstaller with `pip install pyinstaller` if necessary.
+
+set -e
+
+pyinstaller --onefile download_nfse_gui.py
+
+# Copy configuration file next to the executable
+cp config.json dist/
+
+echo "Executable created in dist/. Copy your certificate (.pfx or .pem) to the same folder."


### PR DESCRIPTION
## Summary
- add `build_exe.sh` helper to run PyInstaller
- update README with instructions to copy `config.json` and certificate

## Testing
- `python -m py_compile download_nfse_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_685dfd784bcc8329bff9ab6c2c10c829