### PR TITLE
Add workflow to build Windows executable

### DIFF
--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -1,0 +1,37 @@
+name: Build Windows executable
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pyinstaller
+
+      - name: Build executable
+        shell: bash
+        run: |
+          pyinstaller --onefile download_nfse_gui.py
+          cp config.json dist/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: download_nfse_gui
+          path: dist/download_nfse_gui.exe

--- a/README.md
+++ b/README.md
@@ -80,5 +80,13 @@ Para criar um executável standalone:
 pip install pyinstaller
 pyinstaller --onefile download_nfse_gui.py
 ```
-
 O executável será gerado dentro da pasta `dist`.
+Copie o `config.json` e o arquivo de certificado (`.pfx` ou `.pem`) para esse
+diretório para que o programa consiga localizá-los em tempo de execução.
+
+Um script auxiliar `build_exe.sh` está disponível para automatizar essas etapas.
+
+Além disso, o repositório possui um workflow do **GitHub Actions** que realiza
+a compilação em um ambiente Windows. Ao enviar alterações para a branch
+`main`, um executável `download_nfse_gui.exe` é disponibilizado como artefato
+na aba *Actions* do repositório.

--- a/build_exe.sh
+++ b/build_exe.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Build the standalone executable for download_nfse_gui.py using PyInstaller.
+# Install PyInstaller with `pip install pyinstaller` if necessary.
+
+set -e
+
+pyinstaller --onefile download_nfse_gui.py
+
+# Copy configuration file next to the executable
+cp config.json dist/
+
+echo "Executable created in dist/. Copy your certificate (.pfx or .pem) to the same folder."


### PR DESCRIPTION
## Summary
- build download_nfse_gui.exe on every push to `main`
- document GitHub Actions workflow in README

## Testing
- `python -m py_compile download_nfse_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_685dfd784bcc8329bff9ab6c2c10c829