### PR TITLE
Sort documentos by NSU before processing

### DIFF
--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -212,6 +212,7 @@ class App:
                         resposta = resp.json()
                         documentos = resposta.get("LoteDFe", [])
                         if resposta.get("StatusProcessamento") == "DOCUMENTOS_LOCALIZADOS" and documentos:
+                            documentos = sorted(documentos, key=lambda d: int(d.get("NSU", 0)))
                             nsu_maior = nsu
                             for nfse in documentos:
                                 nsu_item = int(nfse["NSU"])


### PR DESCRIPTION
## Summary
- sort the `documentos` list by integer NSU prior to processing

## Testing
- `python -m py_compile download_nfse_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_685e07f575fc8329b4179fdce5edf311