### PR TITLE
Restore NSU tests and document pytest usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,12 @@ Além disso, o repositório possui um workflow do **GitHub Actions** que realiza
 a compilação em um ambiente Windows. Ao enviar alterações para a branch
 `main`, todo o conteúdo da pasta `dist` é disponibilizado como artefato na aba
 *Actions*. O executável gerado tem o nome `download_nfse_gui.exe`.
+
+## Testes
+
+Para rodar a suíte de testes, instale o `pytest` em seu ambiente e execute:
+
+```bash
+pip install pytest
+pytest
+```

--- a/tests/test_nsu.py
+++ b/tests/test_nsu.py
@@ -1,0 +1,57 @@
+import os
+import sys
+from pathlib import Path
+import types
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Stub external dependencies used by download_nfse_gui
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+
+crypto = types.ModuleType("cryptography")
+hazmat = types.ModuleType("cryptography.hazmat")
+primitives = types.ModuleType("cryptography.hazmat.primitives")
+serialization = types.ModuleType("cryptography.hazmat.primitives.serialization")
+pkcs12 = types.ModuleType(
+    "cryptography.hazmat.primitives.serialization.pkcs12"
+)
+serialization.Encoding = object()
+serialization.PrivateFormat = object()
+serialization.NoEncryption = object()
+pkcs12.load_key_and_certificates = lambda data, pwd, backend: (None, None, None)
+crypto.hazmat = hazmat
+hazmat.primitives = primitives
+primitives.serialization = serialization
+serialization.pkcs12 = pkcs12
+sys.modules["cryptography"] = crypto
+sys.modules["cryptography.hazmat"] = hazmat
+sys.modules["cryptography.hazmat.primitives"] = primitives
+sys.modules["cryptography.hazmat.primitives.serialization"] = serialization
+sys.modules[
+    "cryptography.hazmat.primitives.serialization.pkcs12"
+] = pkcs12
+
+from download_nfse_gui import ler_ultimo_nsu, salvar_ultimo_nsu
+
+
+def test_salvar_e_ler_nsu(tmp_path: Path) -> None:
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        salvar_ultimo_nsu("12345678901234", 42)
+        file_path = tmp_path / "ultimo_nsu_12345678901234.txt"
+        assert file_path.read_text() == "42"
+        assert ler_ultimo_nsu("12345678901234") == 42
+    finally:
+        os.chdir(cwd)
+
+
+def test_ler_nsu_padrao(tmp_path: Path) -> None:
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        assert ler_ultimo_nsu("99999999999999") == 1
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
## Summary
- reintroduce `tests/test_nsu.py` verifying `ler_ultimo_nsu` and `salvar_ultimo_nsu`
- add instructions for running tests with pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e0f436e588329b36de2b93e27b83c