### PR TITLE
Implement versioned build and autorun stop fix

### DIFF
--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -24,15 +24,20 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt pyinstaller
 
+      - name: Generate version
+        shell: bash
+        run: echo "APP_VERSION=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+
       - name: Build executable
         shell: bash
         run: |
           pyinstaller --onefile --noconsole download_nfse_gui.py
           cp config.json dist/
+          mv dist/download_nfse_gui.exe dist/download_nfse_gui_${APP_VERSION}.exe
           ls -R dist
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: download_nfse_gui
+          name: download_nfse_gui_${{ env.APP_VERSION }}
           path: dist/

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ já utilizando a opção `--noconsole`.
 Além disso, o repositório possui um workflow do **GitHub Actions** que realiza
 a compilação em um ambiente Windows. Ao enviar alterações para a branch
 `main`, todo o conteúdo da pasta `dist` é disponibilizado como artefato na aba
-*Actions*. O executável gerado tem o nome `download_nfse_gui.exe`.
+*Actions*. O executável gerado recebe um sufixo com o número da execução,
+como `download_nfse_gui_42.exe`.
 
 ## Testes
 

--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -64,6 +64,7 @@ class App:
         self.logger = logging.getLogger(__name__)
         self.running = False
         self.thread = None
+        self.user_stop = False
 
         self.start_button = tk.Button(root, text="Iniciar Download", command=self.start)
         self.start_button.pack(side=tk.LEFT, padx=5, pady=5)
@@ -90,6 +91,7 @@ class App:
     def start(self):
         if self.running:
             return
+        self.user_stop = False
         self.running = True
         self.start_button.config(state=tk.DISABLED)
         self.stop_button.config(state=tk.NORMAL)
@@ -101,6 +103,7 @@ class App:
 
     def stop(self):
         self.running = False
+        self.user_stop = True
         self.status_label.config(text="Encerrando... aguarde")
         self.write("Parando processo... aguarde.", log=True)
         self.start_button.config(state=tk.NORMAL)
@@ -264,7 +267,7 @@ class App:
             self.running = False
             self.start_button.config(state=tk.NORMAL)
             self.stop_button.config(state=tk.DISABLED)
-            if self.config.get("auto_start"):
+            if self.config.get("auto_start") and not self.user_stop:
                 self.root.after(1000, self.root.destroy)
 
 REQUIRED_FIELDS = ["cert_path", "cert_pass", "cnpj", "output_dir", "log_dir"]


### PR DESCRIPTION
## Summary
- add version generation step to CI workflow and include run number in artifact name
- fix autorun logic so closing only happens when not interrupted by user
- document workflow versioning behavior in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e123796648329b3f8b0834b66c911