### PR TITLE
Fix release permissions

### DIFF
--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: windows-latest
@@ -49,3 +52,4 @@ jobs:
           tag_name: v${{ env.APP_VERSION }}
           name: v${{ env.APP_VERSION }}
           files: dist/download_nfse_gui_${{ env.APP_VERSION }}.exe
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- give GITHUB_TOKEN permission to create releases
- pass the GITHUB_TOKEN to softprops/action-gh-release

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1b2b89e08329b368395cc6d1cb6d