### PR TITLE
Suporta data de emissão dhEmi nos nomes dos XML

### DIFF
--- a/tests/test_nsu.py
+++ b/tests/test_nsu.py
@@ -62,3 +62,10 @@ def test_extrair_ano_mes() -> None:
     ano, mes = extrair_ano_mes(xml.encode())
     assert ano == "2024"
     assert mes == "05"
+
+
+def test_extrair_ano_mes_dhemi() -> None:
+    xml = "<root><dhEmi>2025-06-25T10:49:08-03:00</dhEmi></root>"
+    ano, mes = extrair_ano_mes(xml.encode())
+    assert ano == "2025"
+    assert mes == "06"


### PR DESCRIPTION
## Summary
- extrair data do XML lê agora as tags `dhEmi` ou `DataEmissao`
- adiciona teste para o novo formato ISO 8601 com timezone

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1bf6f4c883299766a3c9a0525b3c