### PR TITLE
Update builds with --noupx

### DIFF
--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build executable
         shell: bash
         run: |
-          pyinstaller --onefile --noconsole download_nfse_gui.py
+          pyinstaller --onefile --noconsole --noupx download_nfse_gui.py
           cp config.json dist/
           mv dist/download_nfse_gui.exe dist/download_nfse_gui_${APP_VERSION}.exe
           ls -R dist

--- a/README.md
+++ b/README.md
@@ -82,14 +82,18 @@ Para criar um executável standalone:
 
 ```bash
 pip install pyinstaller
-pyinstaller --onefile --noconsole download_nfse_gui.py
+pyinstaller --onefile --noconsole --noupx download_nfse_gui.py
 ```
 O executável será gerado dentro da pasta `dist`.
 Copie o `config.json` e o arquivo de certificado (`.pfx` ou `.pem`) para esse
 diretório para que o programa consiga localizá-los em tempo de execução.
 
 Um script auxiliar `build_exe.sh` está disponível para automatizar essas etapas,
-já utilizando a opção `--noconsole`.
+já utilizando a opção `--noconsole` e adicionando `--noupx` por padrão.
+
+Executáveis gerados pelo PyInstaller podem disparar alertas falsos em alguns
+antivírus. Caso isso ocorra, prefira incluir a opção `--noupx` ao gerar o
+executável para evitar a compactação com UPX.
 
 Além disso, o repositório possui um workflow do **GitHub Actions** que realiza
 a compilação em um ambiente Windows. Ao enviar alterações para a branch

--- a/build_exe.sh
+++ b/build_exe.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-pyinstaller --onefile --noconsole download_nfse_gui.py
+pyinstaller --onefile --noconsole --noupx download_nfse_gui.py
 
 # Copy configuration file next to the executable
 cp config.json dist/


### PR DESCRIPTION
## Summary
- update `build_exe.sh` to pass `--noupx` to PyInstaller
- compile with `--noupx` in the GitHub Actions workflow
- document antivirus warnings and recommend the `--noupx` flag in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1e991f848329868907941c14d819