### PR TITLE
Show version in window title

### DIFF
--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -31,6 +31,10 @@ jobs:
         shell: bash
         run: echo "APP_VERSION=0.${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
 
+      - name: Write version file
+        shell: bash
+        run: echo "__version__ = '${APP_VERSION}'" > version.py
+
       - name: Build executable
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ a compilação em um ambiente Windows. Ao enviar alterações para a branch
 `main`, todo o conteúdo da pasta `dist` é disponibilizado como artefato na aba
 *Actions*. O executável gerado recebe um sufixo no formato `0.<run>` e é
 publicado automaticamente em uma release, como `download_nfse_gui_0.42.exe`.
+O número dessa versão também aparece no título da janela do aplicativo.
 
 ## Testes
 

--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -18,6 +18,11 @@ from tkinter import filedialog, messagebox
 from tkinter.scrolledtext import ScrolledText
 import xml.etree.ElementTree as ET
 
+try:
+    from version import __version__  # type: ignore
+except Exception:
+    __version__ = "0.0.0"
+
 CONFIG_FILE = "config.json"
 
 @contextmanager
@@ -79,7 +84,7 @@ class App:
     def __init__(self, root, config):
         self.root = root
         self.config = config
-        self.root.title("Download NFS-e Portal Nacional")
+        self.root.title(f"Download NFS-e Portal Nacional v{__version__}")
         self.text = ScrolledText(root, width=100, height=30, font=("Consolas", 10))
         self.text.pack(fill=tk.BOTH, expand=True)
         self.status_label = tk.Label(root, text="Pronto", anchor='w')

--- a/version.py
+++ b/version.py
@@ -1,0 +1,2 @@
+"""Version information."""
+__version__ = "0.0.0"


### PR DESCRIPTION
## Summary
- import version info and display it in the GUI title
- store default version in `version.py`
- embed generated version in GitHub workflow
- document that the app shows the release version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e212d801c83299b555b5366216819