### PR TITLE
Add Sobre button with app info

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ O programa lê o `config.json`, faz login com o certificado e salva as notas no 
 Os XMLs são nomeados seguindo o padrão `<prefixo>_AAAA-MM_<chave>.xml` definido
 pela chave `file_prefix`.
 
+A interface gráfica também possui um botão **Sobre** que exibe a versão do
+aplicativo, o autor e o texto completo da licença MIT utilizada.
+
 ## Gerar executável com PyInstaller
 
 Para criar um executável standalone:

--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -23,6 +23,12 @@ try:
 except Exception:
     __version__ = "0.0.0"
 
+LICENSE_FILE = Path(__file__).with_name("LICENSE")
+try:
+    LICENSE_TEXT = LICENSE_FILE.read_text(encoding="utf-8").strip()
+except Exception:
+    LICENSE_TEXT = "MIT License"
+
 CONFIG_FILE = "config.json"
 
 @contextmanager
@@ -113,6 +119,9 @@ class App:
 
         self.settings_button = tk.Button(root, text="Configurações", command=self.open_settings)
         self.settings_button.pack(side=tk.LEFT, padx=5, pady=5)
+
+        self.about_button = tk.Button(root, text="Sobre", command=self.show_about)
+        self.about_button.pack(side=tk.LEFT, padx=5, pady=5)
 
         self.settings_win = None  # referencia para a janela de configuração
 
@@ -216,6 +225,15 @@ class App:
             on_close()
 
         tk.Button(win, text="Salvar", command=save).grid(row=9, column=0, columnspan=3, pady=5)
+
+    def show_about(self) -> None:
+        """Display information about the application."""
+        info = (
+            f"Download NFS-e Portal Nacional v{__version__}\n"
+            "Autor: Renan R. Santos\n\n"
+            f"{LICENSE_TEXT}"
+        )
+        messagebox.showinfo("Sobre", info)
 
     def download_nfse(self):
         try:


### PR DESCRIPTION
## Summary
- add a 'Sobre' (About) button in the GUI
- show version, author and license info
- document the new button in the README
- show license text in the About dialog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f35088e208329bd561cd7c0af85e5