### PR TITLE
Search PyInstaller paths for license

### DIFF
--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -25,6 +25,12 @@ except Exception:
 
 LICENSE_FILE = Path(sys.argv[0]).resolve().with_name("LICENSE")
 if not LICENSE_FILE.exists():
+    LICENSE_FILE = Path(sys.executable).resolve().with_name("LICENSE")
+if not LICENSE_FILE.exists() and hasattr(sys, "_MEIPASS"):
+    candidate = Path(sys._MEIPASS) / "LICENSE"
+    if candidate.exists():
+        LICENSE_FILE = candidate
+if not LICENSE_FILE.exists():
     LICENSE_FILE = Path(__file__).resolve().with_name("LICENSE")
 try:
     LICENSE_TEXT = LICENSE_FILE.read_text(encoding="utf-8").strip()


### PR DESCRIPTION
## Summary
- look for the LICENSE relative to `sys.executable`
- support the `_MEIPASS` directory used by PyInstaller

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f3ff2382483298a683bfcde27b5c6