### PR TITLE
Add license path helper and update tests

### DIFF
--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -23,9 +23,34 @@ try:
 except Exception:
     __version__ = "0.0.0"
 
-LICENSE_FILE = Path(sys.argv[0]).resolve().with_name("LICENSE")
-if not LICENSE_FILE.exists():
-    LICENSE_FILE = Path(__file__).resolve().with_name("LICENSE")
+
+def get_license_path() -> Path:
+    """Return the path to the license file.
+
+    The search order is:
+
+    1. Command line argument ``--license=PATH``.
+    2. Environment variable ``LICENSE_PATH``.
+    3. ``LICENSE`` next to ``sys.argv[0]`` if it exists, falling back to
+       the directory of ``__file__``.
+    """
+
+    prefix = "--license="
+    for arg in sys.argv[1:]:
+        if arg.startswith(prefix):
+            return Path(arg[len(prefix) :]).expanduser().resolve()
+
+    env_path = os.getenv("LICENSE_PATH")
+    if env_path:
+        return Path(env_path).expanduser().resolve()
+
+    path = Path(sys.argv[0]).resolve().with_name("LICENSE")
+    if path.exists():
+        return path
+    return Path(__file__).resolve().with_name("LICENSE")
+
+
+LICENSE_FILE = get_license_path()
 try:
     LICENSE_TEXT = LICENSE_FILE.read_text(encoding="utf-8").strip()
 except Exception:

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -1,6 +1,10 @@
+import importlib
+import os
 import sys
 from pathlib import Path
 import types
+
+import pytest
 
 # Ensure repository root is on the path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -27,8 +31,36 @@ sys.modules["cryptography.hazmat.primitives"] = primitives
 sys.modules["cryptography.hazmat.primitives.serialization"] = serialization
 sys.modules["cryptography.hazmat.primitives.serialization.pkcs12"] = pkcs12
 
-from download_nfse_gui import LICENSE_TEXT
+import download_nfse_gui
 
-def test_license_text_read() -> None:
+
+def reload_gui(monkeypatch, args=None, env=None):
+    args = args or []
+    env = env or {}
+    monkeypatch.setattr(sys, "argv", ["prog"] + args)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return importlib.reload(download_nfse_gui)
+
+
+def test_license_text_read(monkeypatch) -> None:
+    mod = reload_gui(monkeypatch)
     license_file = Path(__file__).resolve().parents[1] / "LICENSE"
-    assert LICENSE_TEXT == license_file.read_text(encoding="utf-8").strip()
+    assert mod.LICENSE_FILE == license_file
+    assert mod.LICENSE_TEXT == license_file.read_text(encoding="utf-8").strip()
+
+
+def test_license_arg(monkeypatch, tmp_path) -> None:
+    custom = tmp_path / "my_license"
+    custom.write_text("ARG")
+    mod = reload_gui(monkeypatch, args=[f"--license={custom}"])
+    assert mod.LICENSE_FILE == custom.resolve()
+    assert mod.LICENSE_TEXT == "ARG"
+
+
+def test_license_env(monkeypatch, tmp_path) -> None:
+    custom = tmp_path / "env_license"
+    custom.write_text("ENV")
+    mod = reload_gui(monkeypatch, env={"LICENSE_PATH": str(custom)})
+    assert mod.LICENSE_FILE == custom.resolve()
+    assert mod.LICENSE_TEXT == "ENV"


### PR DESCRIPTION
## Summary
- add `get_license_path()` for locating the license file
- use this helper for `LICENSE_FILE`
- update tests to cover CLI and env based license lookup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4d2db4f88329b0761dc320190490