### PR TITLE
Embed LICENSE_TEXT constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ pela chave `file_prefix`.
 
 A interface gráfica também possui um botão **Sobre** que exibe a versão do
 aplicativo, o autor e o texto completo da licença MIT utilizada. O texto da
-licença é lido dinamicamente do arquivo `LICENSE` localizado no mesmo
-diretório do programa.
+licença já está embutido no código, portanto não é necessário distribuir o
+arquivo `LICENSE` junto com o executável.
 
 ## Gerar executável com PyInstaller
 
@@ -90,9 +90,8 @@ pip install pyinstaller
 pyinstaller --onefile --noconsole --noupx download_nfse_gui.py
 ```
 O executável será gerado dentro da pasta `dist`.
-Copie o `config.json`, o arquivo de certificado (`.pfx` ou `.pem`) **e o
-`LICENSE`** para esse diretório para que o programa consiga localizá-los em
-tempo de execução.
+Copie o `config.json` e o arquivo de certificado (`.pfx` ou `.pem`) para esse
+diretório para que o programa consiga localizá-los em tempo de execução.
 
 Um script auxiliar `build_exe.sh` está disponível para automatizar essas etapas,
 já utilizando a opção `--noconsole` e adicionando `--noupx` por padrão.

--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -9,8 +9,14 @@ import logging
 import sys
 from pathlib import Path
 from contextlib import contextmanager
-from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, NoEncryption
-from cryptography.hazmat.primitives.serialization.pkcs12 import load_key_and_certificates
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    PrivateFormat,
+    NoEncryption,
+)
+from cryptography.hazmat.primitives.serialization.pkcs12 import (
+    load_key_and_certificates,
+)
 import tempfile
 import threading
 import tkinter as tk
@@ -23,13 +29,7 @@ try:
 except Exception:
     __version__ = "0.0.0"
 
-LICENSE_FILE = Path(sys.argv[0]).resolve().with_name("LICENSE")
-if not LICENSE_FILE.exists():
-    LICENSE_FILE = Path(__file__).resolve().with_name("LICENSE")
-try:
-    LICENSE_TEXT = LICENSE_FILE.read_text(encoding="utf-8").strip()
-except Exception:
-    LICENSE_TEXT = "MIT License"
+from license_text import LICENSE_TEXT
 
 CONFIG_FILE = "config.json"
 

--- a/license_text.py
+++ b/license_text.py
@@ -1,0 +1,21 @@
+LICENSE_TEXT = """MIT License
+
+Copyright (c) 2025 Renan R. Santos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \"Software\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE."""

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -1,34 +1,12 @@
 import sys
 from pathlib import Path
-import types
 
 # Ensure repository root is on the path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-# Stub external dependencies used by download_nfse_gui
-sys.modules.setdefault("requests", types.ModuleType("requests"))
+from license_text import LICENSE_TEXT
 
-crypto = types.ModuleType("cryptography")
-hazmat = types.ModuleType("cryptography.hazmat")
-primitives = types.ModuleType("cryptography.hazmat.primitives")
-serialization = types.ModuleType("cryptography.hazmat.primitives.serialization")
-pkcs12 = types.ModuleType("cryptography.hazmat.primitives.serialization.pkcs12")
-serialization.Encoding = object()
-serialization.PrivateFormat = object()
-serialization.NoEncryption = object()
-pkcs12.load_key_and_certificates = lambda data, pwd, backend: (None, None, None)
-crypto.hazmat = hazmat
-hazmat.primitives = primitives
-primitives.serialization = serialization
-serialization.pkcs12 = pkcs12
-sys.modules["cryptography"] = crypto
-sys.modules["cryptography.hazmat"] = hazmat
-sys.modules["cryptography.hazmat.primitives"] = primitives
-sys.modules["cryptography.hazmat.primitives.serialization"] = serialization
-sys.modules["cryptography.hazmat.primitives.serialization.pkcs12"] = pkcs12
 
-from download_nfse_gui import LICENSE_TEXT
-
-def test_license_text_read() -> None:
+def test_license_text_embedded() -> None:
     license_file = Path(__file__).resolve().parents[1] / "LICENSE"
     assert LICENSE_TEXT == license_file.read_text(encoding="utf-8").strip()


### PR DESCRIPTION
## Summary
- add `license_text.py` module with the MIT license string embedded
- load `LICENSE_TEXT` from the new module in `download_nfse_gui.py`
- simplify `tests/test_license.py` to validate the embedded text
- update README to note the license is embedded and remove copying instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f56fc18548329859197e700784d96