### PR TITLE
Fix config changes apply immediately

### DIFF
--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -152,6 +152,8 @@ class App:
             new_cfg["auto_start"] = auto_start_var.get()
             new_cfg["download_pdf"] = pdf_var.get()
             self.config = new_cfg
+            # Update the downloader instance so new settings take effect
+            self.downloader.config = new_cfg
             salvar_config(new_cfg)
             messagebox.showinfo("Configurações", "Configurações salvas com sucesso!")
             on_close()


### PR DESCRIPTION
## Summary
- reload downloader config after saving settings so that changes take effect without restarting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f73cc1e6c8329a0425454502f71f1