### PR TITLE
Add session handling and graceful GUI stop

### DIFF
--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -81,6 +81,9 @@ class App:
     def stop(self):
         self.running = False
         self.user_stop = True
+        self.downloader.close()
+        if self.thread and self.thread.is_alive():
+            self.thread.join(timeout=1)
         self.status_label.config(text="Encerrando... aguarde")
         self.write("Parando processo... aguarde.", log=True)
         self.start_button.config(state=tk.NORMAL)


### PR DESCRIPTION
## Summary
- track requests session in `NFSeDownloader`
- add `close()` helper
- clean up session at the end of downloads
- make GUI stop action close the downloader session and join the thread

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f7539e3a88329b37d1e6f3cea8c0a