### PR TITLE
Add dedicated log line for NSU download

### DIFF
--- a/nfse/downloader.py
+++ b/nfse/downloader.py
@@ -186,7 +186,11 @@ class NFSeDownloader:
                                 if not os.path.exists(filename):
                                     with open(filename, "wb") as fxml:
                                         fxml.write(xml_bytes)
-                                    write(f"XML Baixado e salvo: {filename}", log=True)
+                                    write(f"NSU {nsu_item}", log=True)
+                                    write(
+                                        f"XML Baixado e salvo: {filename}",
+                                        log=True,
+                                    )
                                     total_baixados += 1
                                 if download_pdf and running():
                                     pdf_file = os.path.join(


### PR DESCRIPTION
## Summary
- log the NSU on its own line before logging the XML download message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f7e023da88329bbe9bffffa5133cc