### PR TITLE
Add dhEvento fallback in date extraction

### DIFF
--- a/nfse/downloader.py
+++ b/nfse/downloader.py
@@ -55,12 +55,12 @@ class NFSeDownloader:
 
     @staticmethod
     def extrair_ano_mes(xml_bytes: bytes) -> tuple[str, str]:
-        """Return the year and month from the XML's emission date."""
+        """Return the year and month from ``dhEmi`` or ``dhEvento``."""
         now = datetime.datetime.now()
         try:
             root = ET.fromstring(xml_bytes)
             el = None
-            for tag in ("dhEmi", "DataEmissao"):
+            for tag in ("dhEmi", "dhEvento", "DataEmissao"):
                 el = root.find(f'.//{{*}}{tag}')
                 if el is not None and el.text:
                     break

--- a/tests/test_nsu.py
+++ b/tests/test_nsu.py
@@ -84,3 +84,10 @@ def test_extrair_ano_mes_dhemi() -> None:
     ano, mes = NFSeDownloader.extrair_ano_mes(xml.encode())
     assert ano == "2025"
     assert mes == "06"
+
+
+def test_extrair_ano_mes_dhevento() -> None:
+    xml = "<root><dhEvento>2026-12-31T23:59:59-03:00</dhEvento></root>"
+    ano, mes = NFSeDownloader.extrair_ano_mes(xml.encode())
+    assert ano == "2026"
+    assert mes == "12"


### PR DESCRIPTION
## Summary
- support `<dhEvento>` when `<dhEmi>` is missing when extracting year/month
- test the fallback logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e86f33448329bfd48e42936a173a