### PR TITLE
Fix bottom bar persistence on window resize

### DIFF
--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -28,26 +28,33 @@ class App:
         self.root.title(f"Download NFS-e Portal Nacional v{__version__}")
         self.text = ScrolledText(root, width=100, height=30, font=("Consolas", 10))
         self.text.pack(fill=tk.BOTH, expand=True)
-        self.status_label = tk.Label(root, text="Pronto", anchor='w')
+
+        bottom = tk.Frame(root)
+        bottom.pack(fill=tk.X)
+
+        self.status_label = tk.Label(bottom, text="Pronto", anchor='w')
         self.status_label.pack(fill=tk.X)
+
+        btns = tk.Frame(bottom)
+        btns.pack(fill=tk.X)
         self.logger = logging.getLogger(__name__)
         self.running = False
         self.thread = None
         self.user_stop = False
         self.downloader = NFSeDownloader(config)
 
-        self.start_button = tk.Button(root, text="Iniciar Download", command=self.start)
+        self.start_button = tk.Button(btns, text="Iniciar Download", command=self.start)
         self.start_button.pack(side=tk.LEFT, padx=5, pady=5)
-        self.stop_button = tk.Button(root, text="Parar", command=self.stop, state=tk.DISABLED)
+        self.stop_button = tk.Button(btns, text="Parar", command=self.stop, state=tk.DISABLED)
         self.stop_button.pack(side=tk.LEFT, padx=5, pady=5)
 
-        self.settings_button = tk.Button(root, text="Configurações", command=self.open_settings)
+        self.settings_button = tk.Button(btns, text="Configurações", command=self.open_settings)
         self.settings_button.pack(side=tk.LEFT, padx=5, pady=5)
 
-        self.about_button = tk.Button(root, text="Sobre", command=self.show_about)
+        self.about_button = tk.Button(btns, text="Sobre", command=self.show_about)
         self.about_button.pack(side=tk.LEFT, padx=5, pady=5)
 
-        self.nsu_button = tk.Button(root, text="Editar NSU", command=self.open_nsu_editor)
+        self.nsu_button = tk.Button(btns, text="Editar NSU", command=self.open_nsu_editor)
         self.nsu_button.pack(side=tk.LEFT, padx=5, pady=5)
 
         self.settings_win = None  # referencia para a janela de configuração


### PR DESCRIPTION
## Summary
- create bottom frame in GUI so status bar and buttons stay visible
- place buttons in child frame for correct layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e8b929b48329a3f74b38de77bdc3