### PR TITLE
Create default config file automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install -r requirements.txt
 
 ## Arquivo `config.json`
 
-Crie um arquivo `config.json` na raiz do projeto com as seguintes chaves:
+Se não existir, o programa criará um `config.json` padrão automaticamente. Ele deve conter as seguintes chaves:
 
 - `cert_path`: caminho para o certificado `.pfx` ou `.pem`.
 - `cert_pass`: senha do certificado.

--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -22,9 +22,9 @@ CONFIG_FILE = "config.json"
 
 # Valores padrao para criacao automatica do arquivo de configuracao
 DEFAULT_CONFIG = {
-    "cert_path": "",
-    "cert_pass": "",
-    "cnpj": "",
+    "cert_path": "caminho/para/certificado.pfx",
+    "cert_pass": "sua_senha",
+    "cnpj": "00000000000000",
     "output_dir": "./xml",
     "log_dir": "logs",
     "file_prefix": "NFS-e",

--- a/download_nfse_gui.py
+++ b/download_nfse_gui.py
@@ -20,6 +20,20 @@ from license_text import LICENSE_TEXT
 
 CONFIG_FILE = "config.json"
 
+# Valores padrao para criacao automatica do arquivo de configuracao
+DEFAULT_CONFIG = {
+    "cert_path": "",
+    "cert_pass": "",
+    "cnpj": "",
+    "output_dir": "./xml",
+    "log_dir": "logs",
+    "file_prefix": "NFS-e",
+    "download_pdf": False,
+    "delay_seconds": 60,
+    "auto_start": False,
+    "timeout": 30,
+}
+
 
 class App:
     def __init__(self, root, config):
@@ -259,20 +273,22 @@ class App:
 REQUIRED_FIELDS = ["cert_path", "cert_pass", "cnpj", "output_dir", "log_dir"]
 
 def ler_config():
+    created = False
     if not os.path.exists(CONFIG_FILE):
-        raise FileNotFoundError(f"Arquivo de configuração '{CONFIG_FILE}' não encontrado.")
-    with open(CONFIG_FILE, "r", encoding="utf-8") as f:
-        cfg = json.load(f)
+        cfg = DEFAULT_CONFIG.copy()
+        salvar_config(cfg)
+        created = True
+    else:
+        with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+            cfg = json.load(f)
+
+    for k, v in DEFAULT_CONFIG.items():
+        cfg.setdefault(k, v)
 
     missing = [k for k in REQUIRED_FIELDS if not cfg.get(k)]
-    if missing:
+    if missing and not created:
         raise ValueError("Campos obrigatórios ausentes no config.json: " + ", ".join(missing))
 
-    cfg.setdefault("delay_seconds", 60)
-    cfg.setdefault("timeout", 30)
-    cfg.setdefault("auto_start", False)
-    cfg.setdefault("file_prefix", "NFS-e")
-    cfg.setdefault("download_pdf", False)
     return cfg
 
 def salvar_config(cfg):

--- a/tests/test_config_creation.py
+++ b/tests/test_config_creation.py
@@ -1,0 +1,18 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import download_nfse_gui
+
+
+def test_ler_config_creates_file(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr(download_nfse_gui, "CONFIG_FILE", str(cfg_file))
+    cfg = download_nfse_gui.ler_config()
+    assert cfg_file.exists()
+    assert cfg == download_nfse_gui.DEFAULT_CONFIG
+    # file content should match returned config
+    data = json.loads(cfg_file.read_text(encoding="utf-8"))
+    assert data == cfg


### PR DESCRIPTION
## Summary
- generate a default `config.json` when none is found
- mention automatic config creation in README
- test new `ler_config` behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ea17e0c48329aa583f848574fcd8