### PR TITLE
Fix NSU save logic when interrupted

### DIFF
--- a/nfse/downloader.py
+++ b/nfse/downloader.py
@@ -221,7 +221,7 @@ class NFSeDownloader:
                                 nsu_maior = max(nsu_maior, nsu_item)
                                 self.salvar_ultimo_nsu(nsu_maior + 1, cnpj)
                             if stop_loop or not running():
-                                self.salvar_ultimo_nsu(nsu_maior + 1, cnpj)
+                                self.salvar_ultimo_nsu(max(1, nsu_maior), cnpj)
                                 break
                             self.salvar_ultimo_nsu(nsu_maior + 1, cnpj)
                             nsu = nsu_maior + 1
@@ -237,7 +237,7 @@ class NFSeDownloader:
                             time.sleep(1)
                     elif resp.status_code == 204:
                         write("Nenhuma nota encontrada. Fim da consulta.", log=True)
-                        self.salvar_ultimo_nsu(nsu, cnpj)
+                        self.salvar_ultimo_nsu(max(1, nsu - 1), cnpj)
                         break
                     else:
                         self.logger.error("Erro: %s %s", resp.status_code, resp.text)

--- a/nfse/downloader.py
+++ b/nfse/downloader.py
@@ -237,7 +237,7 @@ class NFSeDownloader:
                             time.sleep(1)
                     elif resp.status_code == 204:
                         write("Nenhuma nota encontrada. Fim da consulta.", log=True)
-                        self.salvar_ultimo_nsu(max(1, nsu - 1), cnpj)
+                        self.salvar_ultimo_nsu(nsu, cnpj)
                         break
                     else:
                         self.logger.error("Erro: %s %s", resp.status_code, resp.text)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -98,4 +98,4 @@ def test_run_updates_nsu(tmp_path, monkeypatch):
 
     nsu_file = tmp_path / "ultimo_nsu_123.txt"
     assert nsu_file.exists()
-    assert nsu_file.read_text() == "2"
+    assert nsu_file.read_text() == "1"


### PR DESCRIPTION
## Summary
- refine last NSU updates for interrupted runs
- adjust the expectation in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862112069d4832980381a68e82991e1