### PR TITLE
Introduce Config dataclass

### DIFF
--- a/nfse/__init__.py
+++ b/nfse/__init__.py
@@ -1,4 +1,5 @@
 from .downloader import NFSeDownloader
 from .pdf_downloader import NFSePDFDownloader
+from .config import Config
 
-__all__ = ["NFSeDownloader", "NFSePDFDownloader"]
+__all__ = ["NFSeDownloader", "NFSePDFDownloader", "Config"]

--- a/nfse/config.py
+++ b/nfse/config.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, asdict
+
+
+@dataclass
+class Config:
+    cert_path: str = "caminho/para/certificado.pfx"
+    cert_pass: str = "sua_senha"
+    cnpj: str = "00000000000000"
+    output_dir: str = "./xml"
+    log_dir: str = "logs"
+    file_prefix: str = "NFS-e"
+    download_pdf: bool = False
+    delay_seconds: int = 60
+    auto_start: bool = False
+    timeout: int = 30
+
+    REQUIRED_FIELDS = ["cert_path", "cert_pass", "cnpj", "output_dir", "log_dir"]
+
+    @classmethod
+    def load(cls, path: str) -> "Config":
+        """Load configuration from ``path`` or create it with defaults."""
+        created = False
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        else:
+            data = {}
+            created = True
+        cfg_data = asdict(cls())
+        cfg_data.update(data)
+        cfg = cls(**cfg_data)
+        missing = [k for k in cls.REQUIRED_FIELDS if not getattr(cfg, k)]
+        if missing and not created:
+            raise ValueError(
+                "Campos obrigatórios ausentes no config.json: " + ", ".join(missing)
+            )
+        if created:
+            cfg.save(path)
+        return cfg
+
+    def save(self, path: str) -> None:
+        """Persist configuration to ``path`` as JSON."""
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(asdict(self), f, indent=2, ensure_ascii=False)

--- a/nfse/downloader.py
+++ b/nfse/downloader.py
@@ -13,6 +13,7 @@ import xml.etree.ElementTree as ET
 import requests
 
 from .pdf_downloader import NFSePDFDownloader
+from .config import Config
 
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
@@ -27,7 +28,7 @@ from cryptography.hazmat.primitives.serialization.pkcs12 import (
 class NFSeDownloader:
     """Utility class to download NFS-e documents."""
 
-    def __init__(self, config: dict):
+    def __init__(self, config: Config):
         self.config = config
         self.logger = logging.getLogger(__name__)
         self.session: Optional[requests.Session] = None
@@ -35,7 +36,7 @@ class NFSeDownloader:
     def ler_ultimo_nsu(self, cnpj: Optional[str] = None) -> int:
         """Return the last stored NSU for ``cnpj`` (defaults to config)."""
         if cnpj is None:
-            cnpj = self.config.get("cnpj", "")
+            cnpj = self.config.cnpj
         fname = f"ultimo_nsu_{cnpj}.txt"
         if os.path.exists(fname):
             with open(fname, "r", encoding="utf-8") as f:
@@ -48,7 +49,7 @@ class NFSeDownloader:
     def salvar_ultimo_nsu(self, nsu: int, cnpj: Optional[str] = None) -> None:
         """Persist ``nsu`` for ``cnpj`` (defaults to config)."""
         if cnpj is None:
-            cnpj = self.config.get("cnpj", "")
+            cnpj = self.config.cnpj
         fname = f"ultimo_nsu_{cnpj}.txt"
         with open(fname, "w", encoding="utf-8") as f:
             f.write(str(nsu))
@@ -88,9 +89,9 @@ class NFSeDownloader:
     ) -> Iterable[str]:
         """Convert ``pfx_path`` to a temporary PEM file."""
         if pfx_path is None:
-            pfx_path = self.config.get("cert_path")
+            pfx_path = self.config.cert_path
         if pfx_password is None:
-            pfx_password = self.config.get("cert_pass")
+            pfx_password = self.config.cert_pass
         data = Path(pfx_path).read_bytes()
         priv_key, cert, add_certs = load_key_and_certificates(
             data, pfx_password.encode(), None
@@ -116,15 +117,15 @@ class NFSeDownloader:
     ) -> None:
         """Download NFS-e documents until ``running`` returns ``False``."""
         cfg = self.config
-        cert_path = cfg["cert_path"]
-        cert_pass = cfg["cert_pass"]
-        cnpj = cfg["cnpj"]
-        output_dir = cfg["output_dir"]
-        log_dir = cfg["log_dir"]
-        file_prefix = cfg.get("file_prefix", "NFS-e")
-        delay_seconds = int(cfg.get("delay_seconds", 60))
-        timeout = int(cfg.get("timeout", 30))
-        download_pdf = bool(cfg.get("download_pdf", False))
+        cert_path = cfg.cert_path
+        cert_pass = cfg.cert_pass
+        cnpj = cfg.cnpj
+        output_dir = cfg.output_dir
+        log_dir = cfg.log_dir
+        file_prefix = cfg.file_prefix
+        delay_seconds = int(cfg.delay_seconds)
+        timeout = int(cfg.timeout)
+        download_pdf = bool(cfg.download_pdf)
 
         os.makedirs(output_dir, exist_ok=True)
         os.makedirs(log_dir, exist_ok=True)

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -87,7 +87,7 @@ def test_show_about_open_close(monkeypatch):
     App = download_nfse_gui.App
     app = App.__new__(App)
     app.root = None
-    app.config = {}
+    app.config = download_nfse_gui.Config()
     app.about_win = None
 
     app.show_about()

--- a/tests/test_config_creation.py
+++ b/tests/test_config_creation.py
@@ -5,14 +5,16 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import download_nfse_gui
+from dataclasses import asdict
+from nfse.config import Config
 
 
 def test_ler_config_creates_file(tmp_path, monkeypatch):
     cfg_file = tmp_path / "config.json"
     monkeypatch.setattr(download_nfse_gui, "CONFIG_FILE", str(cfg_file))
-    cfg = download_nfse_gui.ler_config()
+    cfg = Config.load(str(cfg_file))
     assert cfg_file.exists()
-    assert cfg == download_nfse_gui.DEFAULT_CONFIG
+    assert asdict(cfg) == asdict(Config())
     # file content should match returned config
     data = json.loads(cfg_file.read_text(encoding="utf-8"))
-    assert data == cfg
+    assert data == asdict(cfg)

--- a/tests/test_nsu.py
+++ b/tests/test_nsu.py
@@ -34,13 +34,14 @@ sys.modules[
 ] = pkcs12
 
 from nfse.downloader import NFSeDownloader
+from nfse.config import Config
 
 
 def test_salvar_e_ler_nsu(tmp_path: Path) -> None:
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        dl = NFSeDownloader({"cnpj": "12345678901234"})
+        dl = NFSeDownloader(Config(cnpj="12345678901234"))
         dl.salvar_ultimo_nsu(42)
         file_path = tmp_path / "ultimo_nsu_12345678901234.txt"
         assert file_path.read_text() == "42"
@@ -53,7 +54,7 @@ def test_ler_nsu_padrao(tmp_path: Path) -> None:
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        dl = NFSeDownloader({"cnpj": "99999999999999"})
+        dl = NFSeDownloader(Config(cnpj="99999999999999"))
         assert dl.ler_ultimo_nsu() == 1
     finally:
         os.chdir(cwd)
@@ -63,7 +64,7 @@ def test_salvar_nsu_persiste_novo_obj(tmp_path: Path) -> None:
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        cfg = {"cnpj": "00000000000001"}
+        cfg = Config(cnpj="00000000000001")
         dl = NFSeDownloader(cfg)
         dl.salvar_ultimo_nsu(99)
         dl2 = NFSeDownloader(cfg)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -30,6 +30,7 @@ sys.modules["cryptography.hazmat.primitives.serialization"] = serialization
 sys.modules["cryptography.hazmat.primitives.serialization.pkcs12"] = pkcs12
 
 from nfse.downloader import NFSeDownloader
+from nfse.config import Config
 
 
 class DummyResp:
@@ -71,15 +72,15 @@ def test_run_updates_nsu(tmp_path, monkeypatch):
     import nfse.downloader as dl_mod
     monkeypatch.setattr(dl_mod, "requests", req_mod)
 
-    cfg = {
-        "cert_path": "dummy",
-        "cert_pass": "x",
-        "cnpj": "123",
-        "output_dir": str(tmp_path),
-        "log_dir": str(tmp_path),
-        "delay_seconds": 0,
-        "download_pdf": False,
-    }
+    cfg = Config(
+        cert_path="dummy",
+        cert_pass="x",
+        cnpj="123",
+        output_dir=str(tmp_path),
+        log_dir=str(tmp_path),
+        delay_seconds=0,
+        download_pdf=False,
+    )
 
     dl = NFSeDownloader(cfg)
 


### PR DESCRIPTION
## Summary
- add `nfse/config.py` with `Config` dataclass and JSON load/save helpers
- use the new Config object in downloader and GUI modules
- adapt App configuration dialog for dataclass
- rewrite tests to use `Config` objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686216bf693083299e3f8d7799277ec5