### PR TITLE
Add Windows version info file

### DIFF
--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -33,12 +33,46 @@ jobs:
 
       - name: Write version file
         shell: bash
-        run: echo "__version__ = '${APP_VERSION}'" > version.py
+        run: |
+          echo "__version__ = '${APP_VERSION}'" > version.py
+          cat <<EOF > version_file.txt
+# UTF-8
+VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers=(0, ${APP_VERSION#0.}, 0, 0),
+    prodvers=(0, ${APP_VERSION#0.}, 0, 0),
+    mask=0x3F,
+    flags=0x0,
+    OS=0x4,
+    fileType=0x1,
+    subtype=0x0,
+    date=(0, 0)
+  ),
+  kids=[
+    StringFileInfo([
+      StringTable(
+        '040904B0',
+        [
+          StringStruct('CompanyName', 'Renan R. Santos'),
+          StringStruct('FileDescription', 'Download NFS-e Portal Nacional'),
+          StringStruct('FileVersion', '${APP_VERSION}'),
+          StringStruct('ProductVersion', '${APP_VERSION}'),
+          StringStruct('InternalName', 'download_nfse_gui'),
+          StringStruct('OriginalFilename', 'download_nfse_gui.exe'),
+          StringStruct('ProductName', 'Download NFS-e Portal Nacional')
+        ]
+      )
+    ]),
+    VarFileInfo([VarStruct('Translation', [0x0409, 0x04B0])])
+  ]
+)
+EOF
 
       - name: Build executable
         shell: bash
         run: |
-          pyinstaller --onefile --noconsole --noupx download_nfse_gui.py
+          pyinstaller --onefile --noconsole --noupx \
+            --version-file version_file.txt download_nfse_gui.py
           cp config.json dist/
           mv dist/download_nfse_gui.exe dist/download_nfse_gui_${APP_VERSION}.exe
           ls -R dist

--- a/README.md
+++ b/README.md
@@ -91,11 +91,16 @@ Para criar um executável standalone:
 
 ```bash
 pip install pyinstaller
-pyinstaller --onefile --noconsole --noupx download_nfse_gui.py
+pyinstaller --onefile --noconsole --noupx \
+  --version-file version_file.txt download_nfse_gui.py
 ```
 O executável será gerado dentro da pasta `dist`.
 Copie o `config.json` e o arquivo de certificado (`.pfx` ou `.pem`) para esse
 diretório para que o programa consiga localizá-los em tempo de execução.
+
+O arquivo `version_file.txt` define as informações exibidas na aba **Detalhes**
+das propriedades do executável no Windows. Edite esse arquivo para atualizar
+nome do produto, versão e demais campos conforme necessário.
 
 ### Incluir configurações e recursos adicionais
 

--- a/build_exe.sh
+++ b/build_exe.sh
@@ -4,7 +4,9 @@
 
 set -e
 
-pyinstaller --onefile --noconsole --noupx download_nfse_gui.py
+pyinstaller --onefile --noconsole --noupx \
+  --version-file version_file.txt \
+  download_nfse_gui.py
 
 # Copy license so the About dialog can read it when packaged
 cp LICENSE dist/

--- a/version_file.txt
+++ b/version_file.txt
@@ -1,0 +1,30 @@
+# UTF-8
+VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers=(0, 0, 0, 0),
+    prodvers=(0, 0, 0, 0),
+    mask=0x3F,
+    flags=0x0,
+    OS=0x4,
+    fileType=0x1,
+    subtype=0x0,
+    date=(0, 0)
+  ),
+  kids=[
+    StringFileInfo([
+      StringTable(
+        '040904B0',
+        [
+          StringStruct('CompanyName', 'Renan R. Santos'),
+          StringStruct('FileDescription', 'Download NFS-e Portal Nacional'),
+          StringStruct('FileVersion', '0.0.0'),
+          StringStruct('ProductVersion', '0.0.0'),
+          StringStruct('InternalName', 'download_nfse_gui'),
+          StringStruct('OriginalFilename', 'download_nfse_gui.exe'),
+          StringStruct('ProductName', 'Download NFS-e Portal Nacional')
+        ]
+      )
+    ]),
+    VarFileInfo([VarStruct('Translation', [0x0409, 0x04B0])])
+  ]
+)


### PR DESCRIPTION
## Summary
- embed Windows metadata using PyInstaller `--version-file`
- generate version resource in workflow
- document `version_file.txt` and use it in build command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864a6ed2b0083298479d99f633b2a96