### PR TITLE
Fix NSU query offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ O programa lê o `config.json`, faz login com o certificado e salva as notas no 
 Os XMLs são nomeados seguindo o padrão `<prefixo>_AAAA-MM_<chave>.xml` definido
 pela chave `file_prefix`.
 
+### Continuação de downloads
+
+O script registra o último NSU processado em `ultimo_nsu_<cnpj>.txt` no
+diretório atual. Ao reiniciar, ele consulta sempre o NSU salvo **menos um**,
+requisitando novamente a última nota baixada. Isso evita perdas caso a
+execução seja interrompida.
+
 A interface gráfica também possui um botão **Sobre** que exibe a versão do
 aplicativo, o autor e o texto completo da licença MIT utilizada. O texto da
 licença já está embutido no código, portanto não é necessário distribuir o

--- a/nfse/downloader.py
+++ b/nfse/downloader.py
@@ -152,8 +152,12 @@ class NFSeDownloader:
             nsu = self.ler_ultimo_nsu(cnpj)
             try:
                 while running():
-                    url = f"{base_url}/{nsu:020d}?cnpj={cnpj}"
-                    write(f"Consultando NSU {nsu} para CNPJ {cnpj}...", log=True)
+                    query_nsu = max(0, nsu - 1)
+                    url = f"{base_url}/{query_nsu:020d}?cnpj={cnpj}"
+                    write(
+                        f"Consultando NSU {nsu} (consulta {query_nsu}) para CNPJ {cnpj}...",
+                        log=True,
+                    )
                     try:
                         resp = sess.get(url, timeout=timeout)
                     except requests.exceptions.RequestException as e:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -46,9 +46,11 @@ class DummyResp:
 class DummySession:
     def __init__(self):
         self.calls = 0
+        self.urls = []
 
     def get(self, url, timeout=0):
         self.calls += 1
+        self.urls.append(url)
         if self.calls == 1:
             xml = gzip.compress(b"<xml/>")
             doc = base64.b64encode(xml).decode()
@@ -96,6 +98,10 @@ def test_run_updates_nsu(tmp_path, monkeypatch):
         dl.run(write=lambda *a, **k: None, running=lambda: session.calls < 1)
     finally:
         os.chdir(cwd)
+
+    assert session.urls
+    first_url = session.urls[0]
+    assert first_url.endswith("/00000000000000000000?cnpj=123")
 
     nsu_file = tmp_path / "ultimo_nsu_123.txt"
     assert nsu_file.exists()


### PR DESCRIPTION
## Summary
- query server with the previous NSU
- check request URL in tests
- explain NSU resume logic in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ab14abc48329b5714f6ff7c6cbe8