### PR TITLE
Atualiza URL do download de PDF do portal nacional

### DIFF
--- a/nfse/pdf_downloader.py
+++ b/nfse/pdf_downloader.py
@@ -1,7 +1,7 @@
 class NFSePDFDownloader:
     """Simple helper to download PDF documents from the national portal."""
 
-    BASE_URL = "https://sefin.nfse.gov.br/sefinnacional/danfse"
+    BASE_URL = "https://adn.nfse.gov.br/danfse"
 
     def __init__(self, session, timeout: int = 30):
         self.session = session

--- a/tests/test_pdf_downloader.py
+++ b/tests/test_pdf_downloader.py
@@ -9,7 +9,7 @@ from nfse.pdf_downloader import NFSePDFDownloader
 def test_base_url_constant():
     assert (
         NFSePDFDownloader.BASE_URL
-        == "https://sefin.nfse.gov.br/sefinnacional/danfse"
+        == "https://adn.nfse.gov.br/danfse"
     )
 
 


### PR DESCRIPTION
## Summary
- atualizar a constante BASE_URL do `NFSePDFDownloader` para usar o novo domínio `adn.nfse.gov.br`
- ajustar o teste unitário correspondente para refletir a URL atualizada

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_690d0d9f2c5483299e4092007542bbde